### PR TITLE
Fix CVE dependency issue

### DIFF
--- a/cf-polyfill/pom.xml
+++ b/cf-polyfill/pom.xml
@@ -19,7 +19,7 @@
 
 	<properties>
 		<assembly.mainClass>org.eclipse.californium.tools.PolyfillProxy</assembly.mainClass>
-		<jetty.version>9.2.7.v20150116</jetty.version>
+		<jetty.version>9.4.49.v20220914</jetty.version>
 	</properties>
 
 	<build>


### PR DESCRIPTION
Fix issue #86  by update dependency org.eclipse.jetty.websocket:javax-websocket-server-impl:9.4.49.v20220914 @boaks 